### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Codespaces
 
-Replicates our results in DPL. To replicate out results run the following notebooks:
+Replicates our results in DPL. To replicate our results run the following notebooks:
 
 1 - Maule SCM.ipynb
 


### PR DESCRIPTION
## Summary
- fix typo in README intro

## Testing
- `pytest -q` *(fails: command not found)*