### PR TITLE
Analysis output consistency

### DIFF
--- a/run_analysis.py
+++ b/run_analysis.py
@@ -6,9 +6,10 @@ Runs:
   1. create_maps.py - generates Maule_map.png and Canterbury_map.png
   2. src/nz_outcome_extensions.py - generates NZ decomposition outcome figures/tables
   3. src/sdid_bias_corrected_analysis.py - generates SDID / penalized SCM robustness outputs
-  4. src/sectoral_appendix_analysis.py - sectoral SCM appendix outputs/inference
-  5. Maule SCM.ipynb - generates maule_*, chile_jacknife figures
-  6. Canterbury SCM.ipynb - regenerates nz_*, nz_scm_Construction, nz_scm_Other_Sectors
+  4. Maule SCM.ipynb - generates maule_*, chile_jacknife figures
+  5. Canterbury SCM.ipynb - regenerates nz_*, nz_scm_Construction, nz_scm_Other_Sectors
+  6. src/sectoral_appendix_analysis.py - sectoral SCM appendix outputs/inference (runs last
+     so its nz_scm_Construction.png and nz_scm_Other_Sectors.png are the final versions)
 
 All figures are written to article_assets/ (used by main.tex).
 """
@@ -40,15 +41,9 @@ def main():
         cwd=PROJECT_ROOT,
     )
 
-    # 4. Run sectoral appendix SCM outputs (parallel Chile/NZ sectoral diagnostics).
-    print("Running sectoral SCM appendix script...")
-    subprocess.run(
-        [sys.executable, os.path.join(PROJECT_ROOT, "src", "sectoral_appendix_analysis.py")],
-        check=True,
-        cwd=PROJECT_ROOT,
-    )
-
-    # 5. Execute notebooks (nbconvert --execute runs from notebook's directory)
+    # 4. Execute notebooks (nbconvert --execute runs from notebook's directory)
+    # Note: Notebooks run before sectoral appendix script so that the sectoral script's
+    # outputs (nz_scm_Construction.png, nz_scm_Other_Sectors.png) are the final versions.
     for nb_name in ["Maule SCM.ipynb", "Canterbury SCM.ipynb"]:
         nb_path = os.path.join(NOTEBOOKS_DIR, nb_name)
         if not os.path.exists(nb_path):
@@ -69,6 +64,15 @@ def main():
             check=True,
             cwd=NOTEBOOKS_DIR,
         )
+
+    # 5. Run sectoral appendix SCM outputs (parallel Chile/NZ sectoral diagnostics).
+    # Runs last so its outputs are not overwritten by the notebooks.
+    print("Running sectoral SCM appendix script...")
+    subprocess.run(
+        [sys.executable, os.path.join(PROJECT_ROOT, "src", "sectoral_appendix_analysis.py")],
+        check=True,
+        cwd=PROJECT_ROOT,
+    )
 
     print("Done. Figures saved to article_assets/")
 

--- a/src/sectoral_appendix_analysis.py
+++ b/src/sectoral_appendix_analysis.py
@@ -225,8 +225,10 @@ def _plot_placebo_gaps(
     years = result.years
 
     if mspe_threshold:
-        pre_mspe = gaps.loc[: result.treatment_year].pow(2).sum(axis=0)
-        pre_mspe_treated = treated_gap.loc[: result.treatment_year].pow(2).sum(axis=0)
+        # Use treatment_year - 1 to exclude treatment year from pre-period
+        # (treatment_year is the first post-treatment year per post_mask logic)
+        pre_mspe = gaps.loc[: result.treatment_year - 1].pow(2).sum(axis=0)
+        pre_mspe_treated = treated_gap.loc[: result.treatment_year - 1].pow(2).sum(axis=0)
         keep_units = pre_mspe[pre_mspe < mspe_threshold * pre_mspe_treated].index
         gaps = gaps[keep_units]
 


### PR DESCRIPTION
Fixes two logic bugs: prevents NZ sectoral figures from being overwritten and corrects the placebo pre-fit MSPE filter to exclude post-treatment data.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only analysis orchestration and a plotting/filtering calculation; risk is limited to altered figure/table outputs due to ordering and pre-period MSPE definition.
> 
> **Overview**
> Ensures analysis figure generation is **deterministic** by reordering `run_analysis.py` so the `sectoral_appendix_analysis.py` step runs *after* executing the Maule/Canterbury notebooks, preventing NZ sectoral PNGs from being overwritten.
> 
> Fixes the placebo MSPE filtering in `src/sectoral_appendix_analysis.py` to compute pre-treatment fit error using years up to `treatment_year - 1`, avoiding contamination from the first post-treatment year when selecting which placebo units to keep.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 910e835093f703b629f84daed547bd9e36afa167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->