### PR TITLE
NZ pre-treatment window

### DIFF
--- a/src/predictor_weight_sensitivity.py
+++ b/src/predictor_weight_sensitivity.py
@@ -271,7 +271,7 @@ def main() -> None:
                 time_col="Year",
                 outcome_col="GDP per capita",
                 time_predictors_prior=range(2006, 2011),
-                time_optimize_ssr=range(2000, 2010),
+                time_optimize_ssr=range(2000, 2011),
                 treatment_year=2011,
                 analysis_end_year=2019,
             )
@@ -290,7 +290,7 @@ def main() -> None:
                 time_col="Year",
                 outcome_col="GDP per capita",
                 time_predictors_prior=range(2006, 2011),
-                time_optimize_ssr=range(2000, 2010),
+                time_optimize_ssr=range(2000, 2011),
                 treatment_year=2011,
                 analysis_end_year=2019,
             )


### PR DESCRIPTION
Extend `time_optimize_ssr` for NZ 2011 specifications to include the pre-treatment year 2010.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, parameter-only change to an analysis script; no production runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the New Zealand 2011 runs in `predictor_weight_sensitivity.py` to optimize SSR over `range(2000, 2011)` (including 2010) instead of stopping at 2009, for both the baseline and harmonized predictor specifications.
> 
> This changes the fitting window used for weight selection and will slightly alter the generated `predictor_spec_sensitivity.csv` results for NZ only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b32b142cace185521ac8af032ba8cd0e70b0a74a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->